### PR TITLE
fix: resolve paths before DANGEROUS_ROOTS check (CI fix)

### DIFF
--- a/src/schemas/request.ts
+++ b/src/schemas/request.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import path from 'node:path';
 
 const DANGEROUS_ROOTS = ['/', '/etc', '/usr', '/System', '/bin', '/sbin', '/var'];
 
@@ -6,7 +7,7 @@ export const RequestSchema = z.object({
   task_id: z.string().min(1),
   intent: z.enum(['coding', 'refactor', 'debug', 'ops']),
   workspace_path: z.string().min(1).refine(
-    (p) => !DANGEROUS_ROOTS.includes(p),
+    (p) => !DANGEROUS_ROOTS.includes(path.resolve(p)),
     { message: 'Workspace path is a disallowed root path' }
   ),
   message: z.string().min(1),

--- a/tests/schemas/request.test.ts
+++ b/tests/schemas/request.test.ts
@@ -94,4 +94,14 @@ describe('RequestSchema', () => {
     const result = validateRequest(input);
     expect(result.success).toBe(false);
   });
+
+  it('rejects traversal paths that resolve to dangerous roots', () => {
+    const input = { ...validBase, workspace_path: '/home/user/../../etc' };
+    const result = validateRequest(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i: any) => i.message);
+      expect(messages).toContain('Workspace path is a disallowed root path');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- **Root cause**: `DANGEROUS_ROOTS` check compared raw strings, but `path.join` resolves `..` segments before the value reaches the schema. On Linux `/tmp/x/../../etc` → `/etc` which hit `DANGEROUS_ROOTS` as `REQUEST_INVALID` instead of reaching the runner's `allowed_roots` check (`WORKSPACE_INVALID`). On macOS the same path resolved to `/private/etc`, **bypassing the dangerous root check entirely** — a real security gap.
- **Fix**: `path.resolve()` in the schema refinement so traversal is caught cross-platform
- **Test fix**: runner traversal test now uses a sibling tmpdir instead of a path that lands on `/etc`
- **Regression test**: added `rejects traversal paths that resolve to dangerous roots`

## Test plan
- [x] 103 tests pass locally (16 files)
- [x] Build succeeds
- [ ] CI will self-validate on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)