### PR TITLE
fix: prevent sibling-prefix escape and reject root in allowed_roots

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -32,8 +32,15 @@ export class TaskRunner {
     // Security: resolve workspace and check against allowed_roots
     const resolvedWorkspace = path.resolve(request.workspace_path);
     if (request.allowed_roots && request.allowed_roots.length > 0) {
-      const isAllowed = request.allowed_roots.some(root =>
-        resolvedWorkspace.startsWith(path.resolve(root))
+      const resolvedRoots = request.allowed_roots.map(r => path.resolve(r));
+      const hasFilesystemRoot = resolvedRoots.some(r => r === path.sep);
+      if (hasFilesystemRoot) {
+        await this.fail(runId, startTime, makeError('WORKSPACE_INVALID',
+          'Filesystem root is not permitted as an allowed_root'));
+        return;
+      }
+      const isAllowed = resolvedRoots.some(resolvedRoot =>
+        resolvedWorkspace === resolvedRoot || resolvedWorkspace.startsWith(resolvedRoot + path.sep)
       );
       if (!isAllowed) {
         await this.fail(runId, startTime, makeError('WORKSPACE_INVALID',


### PR DESCRIPTION
## Summary
These fixes were lost during squash merge of PR #5. Re-applying:

- **Sibling-prefix escape**: `startsWith('/tmp/work')` matched `/tmp/work-evil`. Fixed by requiring exact match or `resolvedRoot + path.sep` prefix.
- **Root rejection**: `/` as `allowed_root` defeats the security boundary. Now explicitly rejected.

## Test plan
- [x] 8 runner tests pass including 2 new regression tests
- [x] `rejects filesystem root as allowed_root`
- [x] `rejects sibling-prefix path that shares allowed_root prefix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)