### PR TITLE
fix: guard writeOutputFile and add explicit failure path fields

### DIFF
--- a/src/schemas/errors.ts
+++ b/src/schemas/errors.ts
@@ -1,18 +1,64 @@
 export const ERROR_CODES = {
-  ENGINE_TIMEOUT: { retryable: true, message: 'Engine execution timed out', suggestion: 'Increase --timeout or break the task into smaller steps' },
-  ENGINE_CRASH: { retryable: true, message: 'Engine process crashed', suggestion: 'Engine process crashed unexpectedly, retry the task' },
-  ENGINE_AUTH: { retryable: false, message: 'Engine authentication failed', suggestion: 'Check engine authentication credentials' },
-  NETWORK_ERROR: { retryable: true, message: 'Network connection failed', suggestion: 'Check network connectivity and retry' },
-  WORKSPACE_INVALID: { retryable: false, message: 'Workspace path invalid or out of bounds', suggestion: 'Workspace is outside allowed_roots, use a permitted directory' },
-  WORKSPACE_NOT_FOUND: { retryable: false, message: 'Workspace directory not found', suggestion: 'Verify the workspace path exists' },
-  REQUEST_INVALID: { retryable: false, message: 'Invalid request format', suggestion: 'Check intent, engine, and workspace fields' },
-  RUNNER_CRASH_RECOVERY: { retryable: true, message: 'Orphaned task from runner crash', suggestion: 'Daemon recovered from crash, retry the task' },
-  TASK_STOPPED: { retryable: false, message: 'Task force-stopped by user', suggestion: 'Task was manually stopped, do not auto-retry' },
+  ENGINE_TIMEOUT: {
+    retryable: true,
+    message: "Engine execution timed out",
+    suggestion: "Increase --timeout or break the task into smaller steps",
+  },
+  ENGINE_CRASH: {
+    retryable: true,
+    message: "Engine process crashed",
+    suggestion: "Engine process crashed unexpectedly, retry the task",
+  },
+  ENGINE_AUTH: {
+    retryable: false,
+    message: "Engine authentication failed",
+    suggestion: "Check engine authentication credentials",
+  },
+  NETWORK_ERROR: {
+    retryable: true,
+    message: "Network connection failed",
+    suggestion: "Check network connectivity and retry",
+  },
+  WORKSPACE_INVALID: {
+    retryable: false,
+    message: "Workspace path invalid or out of bounds",
+    suggestion: "Workspace is outside allowed_roots, use a permitted directory",
+  },
+  WORKSPACE_NOT_FOUND: {
+    retryable: false,
+    message: "Workspace directory not found",
+    suggestion: "Verify the workspace path exists",
+  },
+  REQUEST_INVALID: {
+    retryable: false,
+    message: "Invalid request format",
+    suggestion: "Check intent, engine, and workspace fields",
+  },
+  RUNNER_CRASH_RECOVERY: {
+    retryable: true,
+    message: "Orphaned task from runner crash",
+    suggestion: "Daemon recovered from crash, retry the task",
+  },
+  OUTPUT_WRITE_FAILED: {
+    retryable: true,
+    message: "Failed to write output file",
+    suggestion: "Check disk space and permissions in the runs directory",
+  },
+  TASK_STOPPED: {
+    retryable: false,
+    message: "Task force-stopped by user",
+    suggestion: "Task was manually stopped, do not auto-retry",
+  },
 } as const;
 
 export type ErrorCode = keyof typeof ERROR_CODES;
 
 export function makeError(code: ErrorCode, detail?: string) {
   const info = ERROR_CODES[code];
-  return { code, message: detail ?? info.message, retryable: info.retryable, suggestion: info.suggestion };
+  return {
+    code,
+    message: detail ?? info.message,
+    retryable: info.retryable,
+    suggestion: info.suggestion,
+  };
 }

--- a/tests/schemas/errors.test.ts
+++ b/tests/schemas/errors.test.ts
@@ -1,51 +1,56 @@
-import { describe, it, expect } from 'vitest';
-import { ERROR_CODES, makeError, type ErrorCode } from '../../src/schemas/errors.js';
+import { describe, it, expect } from "vitest";
+import {
+  ERROR_CODES,
+  makeError,
+  type ErrorCode,
+} from "../../src/schemas/errors.js";
 
-describe('ERROR_CODES', () => {
-  it('has exactly 9 entries', () => {
-    expect(Object.keys(ERROR_CODES)).toHaveLength(9);
+describe("ERROR_CODES", () => {
+  it("has exactly 10 entries", () => {
+    expect(Object.keys(ERROR_CODES)).toHaveLength(10);
   });
 });
 
-describe('makeError', () => {
-  it('returns correct structure with code, message, retryable, and suggestion', () => {
-    const err = makeError('ENGINE_TIMEOUT');
+describe("makeError", () => {
+  it("returns correct structure with code, message, retryable, and suggestion", () => {
+    const err = makeError("ENGINE_TIMEOUT");
     expect(err).toEqual({
-      code: 'ENGINE_TIMEOUT',
-      message: 'Engine execution timed out',
+      code: "ENGINE_TIMEOUT",
+      message: "Engine execution timed out",
       retryable: true,
       suggestion: expect.any(String),
     });
     expect(err.suggestion!.length).toBeGreaterThan(0);
   });
 
-  it('overrides default message when detail is provided', () => {
-    const err = makeError('ENGINE_TIMEOUT', 'Custom timeout detail');
-    expect(err.code).toBe('ENGINE_TIMEOUT');
-    expect(err.message).toBe('Custom timeout detail');
+  it("overrides default message when detail is provided", () => {
+    const err = makeError("ENGINE_TIMEOUT", "Custom timeout detail");
+    expect(err.code).toBe("ENGINE_TIMEOUT");
+    expect(err.message).toBe("Custom timeout detail");
     expect(err.retryable).toBe(true);
     expect(err.suggestion).toBeTruthy();
   });
 
   it.each([
-    ['ENGINE_TIMEOUT', true],
-    ['ENGINE_CRASH', true],
-    ['ENGINE_AUTH', false],
-    ['NETWORK_ERROR', true],
-    ['WORKSPACE_INVALID', false],
-    ['WORKSPACE_NOT_FOUND', false],
-    ['REQUEST_INVALID', false],
-    ['RUNNER_CRASH_RECOVERY', true],
-    ['TASK_STOPPED', false],
+    ["ENGINE_TIMEOUT", true],
+    ["ENGINE_CRASH", true],
+    ["ENGINE_AUTH", false],
+    ["NETWORK_ERROR", true],
+    ["WORKSPACE_INVALID", false],
+    ["WORKSPACE_NOT_FOUND", false],
+    ["REQUEST_INVALID", false],
+    ["RUNNER_CRASH_RECOVERY", true],
+    ["OUTPUT_WRITE_FAILED", true],
+    ["TASK_STOPPED", false],
   ] as [ErrorCode, boolean][])(
-    '%s has retryable=%s',
+    "%s has retryable=%s",
     (code, expectedRetryable) => {
       const err = makeError(code);
       expect(err.retryable).toBe(expectedRetryable);
     },
   );
 
-  it('every error code has a non-empty suggestion', () => {
+  it("every error code has a non-empty suggestion", () => {
     for (const code of Object.keys(ERROR_CODES) as ErrorCode[]) {
       const err = makeError(code);
       expect(err.suggestion, `${code} should have suggestion`).toBeTruthy();


### PR DESCRIPTION
## Summary

Fixes two issues identified during code review of PR #16:

- **writeOutputFile crash protection**: If `writeOutputFile` throws (disk full, permissions), the runner now catches the error and writes a proper `OUTPUT_WRITE_FAILED` result instead of crashing without a `result.json`
- **Explicit failure path fields**: `fail()` now writes `output_path: null` and `summary_truncated: false` explicitly, instead of relying on schema defaults

## Test plan

- [x] New test: `still writes result.json when writeOutputFile throws` — stubs `writeOutputFile` to throw, verifies `result.json` with `OUTPUT_WRITE_FAILED`
- [x] Updated test: `includes output_path and summary_truncated in failure result` — asserts explicit `null`/`false` instead of `undefined`
- [x] Updated `errors.test.ts` for new `OUTPUT_WRITE_FAILED` error code
- [x] All 208 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)