### PR TITLE
fix: clear stale pid and session_id on resetForResume (#23)

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1,10 +1,10 @@
-import type { RunManager } from './run-manager.js';
-import type { Session } from '../schemas/session.js';
+import type { RunManager } from "./run-manager.js";
+import type { Session } from "../schemas/session.js";
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
-  created: ['running'],
-  running: ['completed', 'failed', 'stopping'],
-  stopping: ['completed', 'failed'],
+  created: ["running"],
+  running: ["completed", "failed", "stopping"],
+  stopping: ["completed", "failed"],
 };
 
 export class SessionManager {
@@ -16,14 +16,14 @@ export class SessionManager {
 
   async transition(
     runId: string,
-    newState: Session['state'],
-    updates?: Partial<Pick<Session, 'pid' | 'session_id'>>
+    newState: Session["state"],
+    updates?: Partial<Pick<Session, "pid" | "session_id">>,
   ): Promise<Session> {
     const current = await this.getSession(runId);
     const allowed = VALID_TRANSITIONS[current.state] ?? [];
     if (!allowed.includes(newState)) {
       throw new Error(
-        `Invalid state transition: ${current.state} \u2192 ${newState} (allowed: ${allowed.join(', ') || 'none'})`
+        `Invalid state transition: ${current.state} \u2192 ${newState} (allowed: ${allowed.join(", ") || "none"})`,
       );
     }
     await this.runManager.updateSession(runId, { state: newState, ...updates });
@@ -32,9 +32,15 @@ export class SessionManager {
 
   async resetForResume(runId: string): Promise<void> {
     const current = await this.getSession(runId);
-    if (current.state !== 'completed' && current.state !== 'failed') {
-      throw new Error(`Cannot resume from state: ${current.state} (must be completed or failed)`);
+    if (current.state !== "completed" && current.state !== "failed") {
+      throw new Error(
+        `Cannot resume from state: ${current.state} (must be completed or failed)`,
+      );
     }
-    await this.runManager.updateSession(runId, { state: 'created' });
+    await this.runManager.updateSession(runId, {
+      state: "created",
+      pid: null,
+      session_id: null,
+    });
   }
 }

--- a/tests/core/session-manager.test.ts
+++ b/tests/core/session-manager.test.ts
@@ -1,133 +1,208 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { SessionManager } from '../../src/core/session-manager.js';
-import { RunManager } from '../../src/core/run-manager.js';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.js";
+import { RunManager } from "../../src/core/run-manager.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 
-describe('SessionManager', () => {
+describe("SessionManager", () => {
   let runsDir: string;
   let runManager: RunManager;
   let sessionManager: SessionManager;
 
-  const createTestRun = () => runManager.createRun({
-    task_id: 'task-001', intent: 'coding', workspace_path: '/tmp/project',
-    message: 'Add login', engine: 'claude-code', mode: 'new',
-  });
+  const createTestRun = () =>
+    runManager.createRun({
+      task_id: "task-001",
+      intent: "coding",
+      workspace_path: "/tmp/project",
+      message: "Add login",
+      engine: "claude-code",
+      mode: "new",
+    });
 
   beforeEach(() => {
-    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebridge-session-'));
+    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebridge-session-"));
     runManager = new RunManager(runsDir);
     sessionManager = new SessionManager(runManager);
   });
 
-  afterEach(() => { fs.rmSync(runsDir, { recursive: true, force: true }); });
-
-  it('initializes session in created state', async () => {
-    const runId = await createTestRun();
-    const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('created');
+  afterEach(() => {
+    fs.rmSync(runsDir, { recursive: true, force: true });
   });
 
-  it('transitions created -> running with pid and session_id', async () => {
+  it("initializes session in created state", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345, session_id: 'sess-abc' });
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('running');
+    expect(session.state).toBe("created");
+  });
+
+  it("transitions created -> running with pid and session_id", async () => {
+    const runId = await createTestRun();
+    await sessionManager.transition(runId, "running", {
+      pid: 12345,
+      session_id: "sess-abc",
+    });
+    const session = await sessionManager.getSession(runId);
+    expect(session.state).toBe("running");
     expect(session.pid).toBe(12345);
-    expect(session.session_id).toBe('sess-abc');
+    expect(session.session_id).toBe("sess-abc");
   });
 
-  it('transitions running -> completed', async () => {
+  it("transitions running -> completed", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'completed');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "completed");
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('completed');
+    expect(session.state).toBe("completed");
   });
 
-  it('transitions running -> failed', async () => {
+  it("transitions running -> failed", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'failed');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "failed");
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('failed');
+    expect(session.state).toBe("failed");
   });
 
-  it('transitions running -> stopping', async () => {
+  it("transitions running -> stopping", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'stopping');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "stopping");
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('stopping');
+    expect(session.state).toBe("stopping");
   });
 
-  it('transitions stopping -> completed', async () => {
+  it("transitions stopping -> completed", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'stopping');
-    await sessionManager.transition(runId, 'completed');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "stopping");
+    await sessionManager.transition(runId, "completed");
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('completed');
+    expect(session.state).toBe("completed");
   });
 
-  it('transitions stopping -> failed', async () => {
+  it("transitions stopping -> failed", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'stopping');
-    await sessionManager.transition(runId, 'failed');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "stopping");
+    await sessionManager.transition(runId, "failed");
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('failed');
+    expect(session.state).toBe("failed");
   });
 
-  it('rejects invalid transition completed -> running', async () => {
+  it("rejects invalid transition completed -> running", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'completed');
-    await expect(sessionManager.transition(runId, 'running')).rejects.toThrow(/invalid state transition/i);
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "completed");
+    await expect(sessionManager.transition(runId, "running")).rejects.toThrow(
+      /invalid state transition/i,
+    );
   });
 
-  it('rejects invalid transition created -> completed', async () => {
+  it("rejects invalid transition created -> completed", async () => {
     const runId = await createTestRun();
-    await expect(sessionManager.transition(runId, 'completed')).rejects.toThrow(/invalid state transition/i);
+    await expect(sessionManager.transition(runId, "completed")).rejects.toThrow(
+      /invalid state transition/i,
+    );
   });
 
-  it('rejects invalid transition failed -> running', async () => {
+  it("rejects invalid transition failed -> running", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'failed');
-    await expect(sessionManager.transition(runId, 'running')).rejects.toThrow(/invalid state transition/i);
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "failed");
+    await expect(sessionManager.transition(runId, "running")).rejects.toThrow(
+      /invalid state transition/i,
+    );
   });
 
-  it('returns updated session from transition', async () => {
+  it("returns updated session from transition", async () => {
     const runId = await createTestRun();
-    const result = await sessionManager.transition(runId, 'running', { pid: 99999, session_id: 'sess-xyz' });
-    expect(result.state).toBe('running');
+    const result = await sessionManager.transition(runId, "running", {
+      pid: 99999,
+      session_id: "sess-xyz",
+    });
+    expect(result.state).toBe("running");
     expect(result.pid).toBe(99999);
-    expect(result.session_id).toBe('sess-xyz');
+    expect(result.session_id).toBe("sess-xyz");
   });
 
-  it('resetForResume resets completed session to created', async () => {
+  it("resetForResume resets completed session to created", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'completed');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "completed");
     await sessionManager.resetForResume(runId);
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('created');
+    expect(session.state).toBe("created");
   });
 
-  it('resetForResume resets failed session to created', async () => {
+  it("resetForResume resets failed session to created", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await sessionManager.transition(runId, 'failed');
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await sessionManager.transition(runId, "failed");
     await sessionManager.resetForResume(runId);
     const session = await sessionManager.getSession(runId);
-    expect(session.state).toBe('created');
+    expect(session.state).toBe("created");
   });
 
-  it('resetForResume rejects running session', async () => {
+  it("resetForResume rejects running session", async () => {
     const runId = await createTestRun();
-    await sessionManager.transition(runId, 'running', { pid: 12345 });
-    await expect(sessionManager.resetForResume(runId)).rejects.toThrow(/cannot resume from state/i);
+    await sessionManager.transition(runId, "running", { pid: 12345 });
+    await expect(sessionManager.resetForResume(runId)).rejects.toThrow(
+      /cannot resume from state/i,
+    );
+  });
+
+  // BDD scenario: Given a completed run with a stale pid from a dead process,
+  //               When resetForResume is called,
+  //               Then the pid should be null so the next runner starts fresh.
+  it("resetForResume clears stale pid after completed run", async () => {
+    const runId = await createTestRun();
+    await sessionManager.transition(runId, "running", { pid: 99999 });
+    await sessionManager.transition(runId, "completed");
+    await sessionManager.resetForResume(runId);
+    const session = await sessionManager.getSession(runId);
+    expect(session.pid).toBeNull();
+  });
+
+  // BDD scenario: Given a failed run with a stale pid from a crashed process,
+  //               When resetForResume is called,
+  //               Then the pid should be null so the next runner starts fresh.
+  it("resetForResume clears stale pid after failed run", async () => {
+    const runId = await createTestRun();
+    await sessionManager.transition(runId, "running", { pid: 99999 });
+    await sessionManager.transition(runId, "failed");
+    await sessionManager.resetForResume(runId);
+    const session = await sessionManager.getSession(runId);
+    expect(session.pid).toBeNull();
+  });
+
+  // BDD scenario: Given a completed run with a session_id from the previous engine invocation,
+  //               When resetForResume is called,
+  //               Then the session_id should be null so the engine allocates a fresh session.
+  it("resetForResume clears stale session_id after completed run", async () => {
+    const runId = await createTestRun();
+    await sessionManager.transition(runId, "running", {
+      pid: 12345,
+      session_id: "old-session-abc",
+    });
+    await sessionManager.transition(runId, "completed");
+    await sessionManager.resetForResume(runId);
+    const session = await sessionManager.getSession(runId);
+    expect(session.session_id).toBeNull();
+  });
+
+  // BDD scenario: Given a failed run with a session_id from the previous engine invocation,
+  //               When resetForResume is called,
+  //               Then the session_id should be null so the engine allocates a fresh session.
+  it("resetForResume clears stale session_id after failed run", async () => {
+    const runId = await createTestRun();
+    await sessionManager.transition(runId, "running", {
+      pid: 12345,
+      session_id: "old-session-xyz",
+    });
+    await sessionManager.transition(runId, "failed");
+    await sessionManager.resetForResume(runId);
+    const session = await sessionManager.getSession(runId);
+    expect(session.session_id).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `SessionManager.resetForResume` was only resetting `state` to `created`, leaving `pid` and `session_id` from the previous (dead) process intact.
- This caused any subsequent runner that inspected those fields to see a ghost PID (e.g. `99999`) and a stale engine session ID, creating confusion about process liveness and engine continuity.
- Fix: pass `pid: null, session_id: null` alongside `state: 'created'` in the `updateSession` call.

## Changes

- **`src/core/session-manager.ts`** — `resetForResume` now clears both `pid` and `session_id` atomically with the state reset.
- **`tests/core/session-manager.test.ts`** — 4 new BDD-style tests covering all four stale-field scenarios (pid + session_id × completed + failed).

## Test plan

- [x] 4 new tests written first (red), then implementation applied (green) — strict TDD cycle observed.
- [x] `npx vitest run tests/core/session-manager.test.ts` — 18/18 pass.
- [x] `npm test` — 212/212 pass, zero regressions.
- [x] `npx tsc --noEmit` — zero TypeScript errors.

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)