### PR TITLE
fix: reconciler handles stopping state and corrupt session.json (#22)

### DIFF
--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -1,12 +1,12 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import type { RunManager } from './run-manager.js';
-import { makeError } from '../schemas/errors.js';
-import { isProcessAlive } from '../utils/process.js';
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { RunManager } from "./run-manager.js";
+import { makeError } from "../schemas/errors.js";
+import { isProcessAlive } from "../utils/process.js";
 
 export interface ReconcileAction {
   runId: string;
-  action: 'marked_failed' | 'marked_completed' | 'kept_running';
+  action: "marked_failed" | "marked_completed" | "kept_running";
   detail: string;
 }
 
@@ -18,13 +18,16 @@ export class Reconciler {
     const line = `${timestamp} [${action.action}] ${action.runId}: ${action.detail}\n`;
 
     // Global reconciliation log
-    const globalLogPath = path.join(runsDir, 'reconciliation.log');
+    const globalLogPath = path.join(runsDir, "reconciliation.log");
     fs.appendFileSync(globalLogPath, line);
 
     // Per-run log
-    const runLogDir = path.join(this.runManager.getRunDir(action.runId), 'logs');
+    const runLogDir = path.join(
+      this.runManager.getRunDir(action.runId),
+      "logs",
+    );
     if (fs.existsSync(runLogDir)) {
-      fs.appendFileSync(path.join(runLogDir, 'reconciliation.log'), line);
+      fs.appendFileSync(path.join(runLogDir, "reconciliation.log"), line);
     }
   }
 
@@ -34,19 +37,24 @@ export class Reconciler {
     const runsDir = this.runManager.getRunsDir();
 
     for (const run of runs) {
-      if (run.state !== 'running') continue;
+      if (run.state !== "running" && run.state !== "stopping") continue;
       if (run.pid && isProcessAlive(run.pid)) continue;
 
-      const resultPath = path.join(this.runManager.getRunDir(run.run_id), 'result.json');
+      const resultPath = path.join(
+        this.runManager.getRunDir(run.run_id),
+        "result.json",
+      );
 
       if (fs.existsSync(resultPath)) {
         try {
-          const result = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
-          const newState = result.status === 'completed' ? 'completed' : 'failed';
+          const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+          const newState =
+            result.status === "completed" ? "completed" : "failed";
           await this.runManager.updateSession(run.run_id, { state: newState });
           const action: ReconcileAction = {
             runId: run.run_id,
-            action: newState === 'completed' ? 'marked_completed' : 'marked_failed',
+            action:
+              newState === "completed" ? "marked_completed" : "marked_failed",
             detail: `Reconciled from result.json (status: ${result.status})`,
           };
           actions.push(action);
@@ -57,20 +65,20 @@ export class Reconciler {
         }
       }
 
-      await this.runManager.updateSession(run.run_id, { state: 'failed' });
+      await this.runManager.updateSession(run.run_id, { state: "failed" });
       await this.runManager.writeResult(run.run_id, {
         run_id: run.run_id,
-        status: 'failed',
-        summary: 'Task orphaned after runner restart',
+        status: "failed",
+        summary: "Task orphaned after runner restart",
         session_id: run.session_id ?? null,
         artifacts: [],
         duration_ms: 0,
         token_usage: null,
-        error: makeError('RUNNER_CRASH_RECOVERY'),
+        error: makeError("RUNNER_CRASH_RECOVERY"),
       });
       const action: ReconcileAction = {
         runId: run.run_id,
-        action: 'marked_failed',
+        action: "marked_failed",
         detail: `Orphaned task (pid ${run.pid} no longer running, missing/corrupt result.json)`,
       };
       actions.push(action);

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -59,8 +59,16 @@ export class RunManager {
       if (!entry.isDirectory()) continue;
       const sessionPath = path.join(this.runsDir, entry.name, "session.json");
       if (!fs.existsSync(sessionPath)) continue;
-      const raw = fs.readFileSync(sessionPath, "utf-8");
-      runs.push({ ...JSON.parse(raw), run_id: entry.name });
+      try {
+        const raw = fs.readFileSync(sessionPath, "utf-8");
+        runs.push({ ...JSON.parse(raw), run_id: entry.name });
+      } catch {
+        // Corrupt or unreadable session.json — skip this entry and continue.
+        // One bad file must not abort the entire listing or kill poll() cycles.
+        process.stderr.write(
+          `[RunManager] Warning: skipping corrupt session.json for run ${entry.name}\n`,
+        );
+      }
     }
     return runs;
   }

--- a/tests/core/reconciler.test.ts
+++ b/tests/core/reconciler.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { Reconciler } from '../../src/core/reconciler';
-import { RunManager } from '../../src/core/run-manager';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Reconciler } from "../../src/core/reconciler";
+import { RunManager } from "../../src/core/run-manager";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 
-describe('Reconciler', () => {
+describe("Reconciler", () => {
   let runsDir: string;
   let runManager: RunManager;
 
   beforeEach(() => {
-    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codebridge-reconcile-'));
+    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), "codebridge-reconcile-"));
     runManager = new RunManager(runsDir);
   });
 
@@ -18,82 +18,88 @@ describe('Reconciler', () => {
     fs.rmSync(runsDir, { recursive: true, force: true });
   });
 
-  it('marks orphaned running task as failed with RUNNER_CRASH_RECOVERY', async () => {
+  it("marks orphaned running task as failed with RUNNER_CRASH_RECOVERY", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-001',
-      intent: 'coding' as const,
-      workspace_path: '/tmp/project',
-      message: 'Orphan',
-      engine: 'claude-code',
-      mode: 'new' as const,
+      task_id: "task-001",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Orphan",
+      engine: "claude-code",
+      mode: "new" as const,
     });
-    await runManager.updateSession(runId, { state: 'running', pid: 99999 });
+    await runManager.updateSession(runId, { state: "running", pid: 99999 });
 
     const reconciler = new Reconciler(runManager);
     const actions = await reconciler.reconcile();
 
     expect(actions).toHaveLength(1);
-    expect(actions[0].action).toBe('marked_failed');
+    expect(actions[0].action).toBe("marked_failed");
     expect(actions[0].runId).toBe(runId);
-    expect(actions[0].detail).toContain('pid 99999');
+    expect(actions[0].detail).toContain("pid 99999");
     const session = await runManager.getStatus(runId);
-    expect(session.state).toBe('failed');
+    expect(session.state).toBe("failed");
     // Check result.json was written
-    const resultPath = path.join(runsDir, runId, 'result.json');
-    const result = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
-    expect(result.error.code).toBe('RUNNER_CRASH_RECOVERY');
+    const resultPath = path.join(runsDir, runId, "result.json");
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(result.error.code).toBe("RUNNER_CRASH_RECOVERY");
     expect(result.error.retryable).toBe(true);
   });
 
-  it('reconciles completed task from result.json', async () => {
+  it("reconciles completed task from result.json", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-002',
-      intent: 'coding' as const,
-      workspace_path: '/tmp/project',
-      message: 'Completed',
-      engine: 'claude-code',
-      mode: 'new' as const,
+      task_id: "task-002",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Completed",
+      engine: "claude-code",
+      mode: "new" as const,
     });
-    await runManager.updateSession(runId, { state: 'running', pid: 99999 });
-    await runManager.writeResult(runId, { status: 'completed', summary: 'Done' });
+    await runManager.updateSession(runId, { state: "running", pid: 99999 });
+    await runManager.writeResult(runId, {
+      status: "completed",
+      summary: "Done",
+    });
 
     const reconciler = new Reconciler(runManager);
     const actions = await reconciler.reconcile();
 
     expect(actions).toHaveLength(1);
-    expect(actions[0].action).toBe('marked_completed');
+    expect(actions[0].action).toBe("marked_completed");
     expect(actions[0].runId).toBe(runId);
     const session = await runManager.getStatus(runId);
-    expect(session.state).toBe('completed');
+    expect(session.state).toBe("completed");
   });
 
-  it('leaves still-running process alone', async () => {
+  it("leaves still-running process alone", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-003',
-      intent: 'coding' as const,
-      workspace_path: '/tmp/project',
-      message: 'Still running',
-      engine: 'claude-code',
-      mode: 'new' as const,
+      task_id: "task-003",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Still running",
+      engine: "claude-code",
+      mode: "new" as const,
     });
-    await runManager.updateSession(runId, { state: 'running', pid: process.pid });
+    await runManager.updateSession(runId, {
+      state: "running",
+      pid: process.pid,
+    });
 
     const reconciler = new Reconciler(runManager);
     const actions = await reconciler.reconcile();
 
     expect(actions).toHaveLength(0);
     const session = await runManager.getStatus(runId);
-    expect(session.state).toBe('running');
+    expect(session.state).toBe("running");
   });
 
-  it('skips non-running sessions', async () => {
+  it("skips non-running sessions", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-004',
-      intent: 'coding' as const,
-      workspace_path: '/tmp/project',
-      message: 'Already done',
-      engine: 'claude-code',
-      mode: 'new' as const,
+      task_id: "task-004",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Already done",
+      engine: "claude-code",
+      mode: "new" as const,
     });
     // state stays 'created' — should be skipped
 
@@ -102,76 +108,180 @@ describe('Reconciler', () => {
     expect(actions).toHaveLength(0);
   });
 
-  it('writes reconciliation actions to log files', async () => {
+  it("writes reconciliation actions to log files", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-log', intent: 'coding', workspace_path: '/tmp/project',
-      message: 'Log test', engine: 'claude-code', mode: 'new',
+      task_id: "task-log",
+      intent: "coding",
+      workspace_path: "/tmp/project",
+      message: "Log test",
+      engine: "claude-code",
+      mode: "new",
     });
-    await runManager.updateSession(runId, { state: 'running', pid: 99999 });
+    await runManager.updateSession(runId, { state: "running", pid: 99999 });
 
     const reconciler = new Reconciler(runManager);
     await reconciler.reconcile();
 
     // Check global log
-    const globalLog = fs.readFileSync(path.join(runsDir, 'reconciliation.log'), 'utf-8');
+    const globalLog = fs.readFileSync(
+      path.join(runsDir, "reconciliation.log"),
+      "utf-8",
+    );
     expect(globalLog).toContain(runId);
-    expect(globalLog).toContain('marked_failed');
+    expect(globalLog).toContain("marked_failed");
 
     // Check per-run log
     const runLog = fs.readFileSync(
-      path.join(runsDir, runId, 'logs', 'reconciliation.log'), 'utf-8'
+      path.join(runsDir, runId, "logs", "reconciliation.log"),
+      "utf-8",
     );
     expect(runLog).toContain(runId);
   });
 
-  it('reconciles failed task from result.json with failed status', async () => {
+  it("reconciles failed task from result.json with failed status", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-005',
-      intent: 'coding' as const,
-      workspace_path: '/tmp/project',
-      message: 'Failed externally',
-      engine: 'claude-code',
-      mode: 'new' as const,
+      task_id: "task-005",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Failed externally",
+      engine: "claude-code",
+      mode: "new" as const,
     });
-    await runManager.updateSession(runId, { state: 'running', pid: 99999 });
+    await runManager.updateSession(runId, { state: "running", pid: 99999 });
     await runManager.writeResult(runId, {
-      status: 'failed',
-      summary: 'Engine crashed',
-      error: { code: 'ENGINE_CRASH', message: 'Engine process crashed', retryable: true },
+      status: "failed",
+      summary: "Engine crashed",
+      error: {
+        code: "ENGINE_CRASH",
+        message: "Engine process crashed",
+        retryable: true,
+      },
     });
 
     const reconciler = new Reconciler(runManager);
     const actions = await reconciler.reconcile();
 
     expect(actions).toHaveLength(1);
-    expect(actions[0].action).toBe('marked_failed');
+    expect(actions[0].action).toBe("marked_failed");
     const session = await runManager.getStatus(runId);
-    expect(session.state).toBe('failed');
+    expect(session.state).toBe("failed");
   });
 
-  it('treats corrupt result.json as orphaned and rewrites failed result', async () => {
+  it("treats corrupt result.json as orphaned and rewrites failed result", async () => {
     const runId = await runManager.createRun({
-      task_id: 'task-006',
-      intent: 'coding' as const,
-      workspace_path: '/tmp/project',
-      message: 'Corrupt result',
-      engine: 'claude-code',
-      mode: 'new' as const,
+      task_id: "task-006",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Corrupt result",
+      engine: "claude-code",
+      mode: "new" as const,
     });
-    await runManager.updateSession(runId, { state: 'running', pid: 99999 });
-    const resultPath = path.join(runsDir, runId, 'result.json');
-    fs.writeFileSync(resultPath, '{ invalid json');
+    await runManager.updateSession(runId, { state: "running", pid: 99999 });
+    const resultPath = path.join(runsDir, runId, "result.json");
+    fs.writeFileSync(resultPath, "{ invalid json");
 
     const reconciler = new Reconciler(runManager);
     const actions = await reconciler.reconcile();
 
     expect(actions).toHaveLength(1);
-    expect(actions[0].action).toBe('marked_failed');
-    expect(actions[0].detail).toContain('missing/corrupt result.json');
+    expect(actions[0].action).toBe("marked_failed");
+    expect(actions[0].detail).toContain("missing/corrupt result.json");
 
     const session = await runManager.getStatus(runId);
-    expect(session.state).toBe('failed');
-    const rewritten = JSON.parse(fs.readFileSync(resultPath, 'utf-8'));
-    expect(rewritten.error.code).toBe('RUNNER_CRASH_RECOVERY');
+    expect(session.state).toBe("failed");
+    const rewritten = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(rewritten.error.code).toBe("RUNNER_CRASH_RECOVERY");
+  });
+
+  // BDD: Bug 1 — stopping state with dead PID should be cleaned up
+  // Scenario: A run is in 'stopping' state with a dead PID
+  //   Given a run that was gracefully stopping
+  //   And the process (PID) has since died
+  //   When the reconciler runs at daemon startup
+  //   Then the run should be marked failed (not left permanently stuck)
+  it("cleans up stopping state with dead PID — marks as failed", async () => {
+    const runId = await runManager.createRun({
+      task_id: "task-stopping-dead",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Stopping but dead",
+      engine: "claude-code",
+      mode: "new" as const,
+    });
+    // Simulate a run stuck in 'stopping' with a dead PID (99999 is not alive)
+    await runManager.updateSession(runId, { state: "stopping", pid: 99999 });
+
+    const reconciler = new Reconciler(runManager);
+    const actions = await reconciler.reconcile();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].action).toBe("marked_failed");
+    expect(actions[0].runId).toBe(runId);
+    const session = await runManager.getStatus(runId);
+    expect(session.state).toBe("failed");
+    // result.json should be written with RUNNER_CRASH_RECOVERY
+    const resultPath = path.join(runsDir, runId, "result.json");
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(result.error.code).toBe("RUNNER_CRASH_RECOVERY");
+  });
+
+  // BDD: Bug 1 — stopping state with live PID should be left alone
+  // Scenario: A run is in 'stopping' state and the process is still alive
+  //   Given a run gracefully stopping
+  //   And the process is still running
+  //   When the reconciler runs
+  //   Then the run should NOT be disturbed
+  it("leaves stopping state with live PID alone", async () => {
+    const runId = await runManager.createRun({
+      task_id: "task-stopping-alive",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Stopping but alive",
+      engine: "claude-code",
+      mode: "new" as const,
+    });
+    // Use current process PID — definitely alive
+    await runManager.updateSession(runId, {
+      state: "stopping",
+      pid: process.pid,
+    });
+
+    const reconciler = new Reconciler(runManager);
+    const actions = await reconciler.reconcile();
+
+    expect(actions).toHaveLength(0);
+    const session = await runManager.getStatus(runId);
+    expect(session.state).toBe("stopping");
+  });
+
+  // BDD: Bug 1 — stopping state with result.json should reconcile from result
+  // Scenario: A run in 'stopping' state has finished writing result.json
+  //   Given a run that completed while it was being asked to stop
+  //   And the process has since died
+  //   And result.json exists with status 'completed'
+  //   When the reconciler runs
+  //   Then the run should be marked completed from result.json
+  it("reconciles stopping state from result.json when process is dead", async () => {
+    const runId = await runManager.createRun({
+      task_id: "task-stopping-with-result",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Stopped with result",
+      engine: "claude-code",
+      mode: "new" as const,
+    });
+    await runManager.updateSession(runId, { state: "stopping", pid: 99999 });
+    await runManager.writeResult(runId, {
+      status: "completed",
+      summary: "Done before stop",
+    });
+
+    const reconciler = new Reconciler(runManager);
+    const actions = await reconciler.reconcile();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].action).toBe("marked_completed");
+    const session = await runManager.getStatus(runId);
+    expect(session.state).toBe("completed");
   });
 });

--- a/tests/core/run-manager.test.ts
+++ b/tests/core/run-manager.test.ts
@@ -176,4 +176,62 @@ describe("RunManager", () => {
     expect(fs.existsSync(outputPath)).toBe(true);
     expect(fs.readFileSync(outputPath, "utf-8")).toBe("");
   });
+
+  // BDD: Bug 2 — corrupt session.json must not abort listRuns()
+  // Scenario: One run directory contains a corrupt (invalid JSON) session.json
+  //   Given three run directories exist
+  //   And one session.json is truncated/corrupt
+  //   When listRuns() is called
+  //   Then the two valid runs are returned (no exception thrown)
+  //   And the corrupt entry is silently skipped
+  it("skips corrupt session.json entries and continues listing valid runs", async () => {
+    const base = {
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Do something",
+      engine: "claude-code",
+      mode: "new" as const,
+    };
+    const runId1 = await manager.createRun({ ...base, task_id: "task-good-1" });
+    const runId2 = await manager.createRun({
+      ...base,
+      task_id: "task-corrupt",
+    });
+    const runId3 = await manager.createRun({ ...base, task_id: "task-good-2" });
+
+    // Corrupt one session.json
+    const corruptSessionPath = path.join(runsDir, runId2, "session.json");
+    fs.writeFileSync(corruptSessionPath, "{ this is not valid json !!!!");
+
+    // Should not throw — corrupt entry is skipped
+    const runs = await manager.listRuns();
+    const ids = runs.map((r) => r.run_id);
+    expect(runs).toHaveLength(2);
+    expect(ids).toContain(runId1);
+    expect(ids).toContain(runId3);
+    expect(ids).not.toContain(runId2);
+  });
+
+  // BDD: Bug 2 — completely empty session.json is also skipped
+  // Scenario: A session.json file is empty (e.g. interrupted write)
+  //   Given a run directory with an empty session.json
+  //   When listRuns() is called
+  //   Then the empty entry is skipped without throwing
+  it("skips empty session.json entries without throwing", async () => {
+    const runId = await manager.createRun({
+      task_id: "task-empty-session",
+      intent: "coding" as const,
+      workspace_path: "/tmp/project",
+      message: "Test",
+      engine: "claude-code",
+      mode: "new" as const,
+    });
+
+    // Overwrite with empty content
+    fs.writeFileSync(path.join(runsDir, runId, "session.json"), "");
+
+    // Should not throw
+    const runs = await manager.listRuns();
+    expect(runs).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes three bugs reported in issue #22 that could cause the daemon to permanently stall:

- **Bug 1 (reconciler.ts:37):** The reconciler's `for` loop only checked `run.state !== 'running'`, silently skipping any run in `stopping` state. A run that was gracefully stopping when the daemon crashed would have a dead PID but never be recovered. Fixed by extending the guard to `run.state !== 'running' && run.state !== 'stopping'`, so stopping-with-dead-PID runs are cleaned up the same way as running-with-dead-PID runs (reconciled from result.json if present, otherwise crash-recovered with `RUNNER_CRASH_RECOVERY`).

- **Bugs 2 & 3 (run-manager.ts:63):** `listRuns()` called `JSON.parse` on each `session.json` without a try/catch. One corrupt or truncated file would throw a `SyntaxError` and abort the entire listing. Since the daemon's `poll()` calls `listRuns()` on every cycle, one corrupt file effectively killed the daemon for all new work. Fixed by wrapping each JSON parse in a try/catch; corrupt entries are skipped with a stderr warning and processing continues for the remaining runs.

## Test plan

- [x] New test: `cleans up stopping state with dead PID — marks as failed` — verifies Bug 1 fix (dead PID, no result.json)
- [x] New test: `leaves stopping state with live PID alone` — verifies the live-PID branch is not disturbed
- [x] New test: `reconciles stopping state from result.json when process is dead` — verifies stopping runs with a completed result.json get correctly marked
- [x] New test: `skips corrupt session.json entries and continues listing valid runs` — verifies Bug 2/3 fix (corrupt file doesn't abort listing)
- [x] New test: `skips empty session.json entries without throwing` — verifies empty-file edge case
- [x] `npm test` — all 213 tests pass, zero regressions
- [x] `npx tsc --noEmit` — TypeScript compiles cleanly under strict mode

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)