### PR TITLE
fix: validate CLI inputs before writing to disk (#25)

### DIFF
--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -1,15 +1,19 @@
-import { Command } from 'commander';
-import { RunManager } from '../../core/run-manager.js';
-import { SessionManager } from '../../core/session-manager.js';
-import path from 'node:path';
+import { Command } from "commander";
+import { RunManager } from "../../core/run-manager.js";
+import { SessionManager } from "../../core/session-manager.js";
+import path from "node:path";
 
 export function resumeCommand(): Command {
-  return new Command('resume')
-    .description('Send follow-up message to an existing session')
-    .argument('<run_id>', 'Run ID to resume')
-    .requiredOption('--message <text>', 'Follow-up message')
-    .option('--wait', 'Block until task completes', false)
-    .option('--runs-dir <path>', 'Runs directory', path.join(process.cwd(), '.runs'))
+  return new Command("resume")
+    .description("Send follow-up message to an existing session")
+    .argument("<run_id>", "Run ID to resume")
+    .requiredOption("--message <text>", "Follow-up message")
+    .option("--wait", "Block until task completes", false)
+    .option(
+      "--runs-dir <path>",
+      "Runs directory",
+      path.join(process.cwd(), ".runs"),
+    )
     .action(async (runId, opts) => {
       const runManager = new RunManager(opts.runsDir);
       const sessionManager = new SessionManager(runManager);
@@ -17,28 +21,36 @@ export function resumeCommand(): Command {
       if (!session.session_id) {
         throw new Error(`Run ${runId} has no session_id and cannot be resumed`);
       }
-      const { writeFileSync, renameSync, readFileSync, existsSync } = await import('node:fs');
+      const { writeFileSync, renameSync, readFileSync, existsSync } =
+        await import("node:fs");
       const runDir = runManager.getRunDir(runId);
 
-      // Get original workspace from request.processing.json
-      let workspacePath = process.cwd();
-      const processingPath = path.join(runDir, 'request.processing.json');
-      if (existsSync(processingPath)) {
-        const original = JSON.parse(readFileSync(processingPath, 'utf-8'));
-        workspacePath = original.workspace_path ?? workspacePath;
+      // Read original workspace and intent from request.processing.json.
+      // Error out if the file is missing — silently falling back to process.cwd()
+      // would resume against the wrong workspace with no way to recover.
+      const processingPath = path.join(runDir, "request.processing.json");
+      if (!existsSync(processingPath)) {
+        process.stderr.write(
+          `Error: request.processing.json not found for run ${runId}. ` +
+            `The original workspace and intent cannot be recovered.\n`,
+        );
+        process.exit(1);
       }
+      const original = JSON.parse(readFileSync(processingPath, "utf-8"));
+      const workspacePath: string = original.workspace_path;
+      const originalIntent: string = original.intent;
 
       const request = {
         task_id: session.run_id,
-        intent: 'coding',
+        intent: originalIntent,
         workspace_path: workspacePath,
         message: opts.message,
         engine: session.engine,
-        mode: 'resume',
+        mode: "resume",
         session_id: session.session_id,
       };
-      const tmpPath = path.join(runDir, 'request.tmp');
-      const finalPath = path.join(runDir, 'request.json');
+      const tmpPath = path.join(runDir, "request.tmp");
+      const finalPath = path.join(runDir, "request.json");
       writeFileSync(tmpPath, JSON.stringify(request, null, 2));
       renameSync(tmpPath, finalPath);
 
@@ -46,17 +58,30 @@ export function resumeCommand(): Command {
       await sessionManager.resetForResume(runId);
 
       if (!opts.wait) {
-        process.stdout.write(JSON.stringify({ run_id: runId, status: 'resume_queued', session_id: session.session_id }, null, 2) + '\n');
+        process.stdout.write(
+          JSON.stringify(
+            {
+              run_id: runId,
+              status: "resume_queued",
+              session_id: session.session_id,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
         return;
       }
 
       // --wait mode: process immediately
-      const { resolveEngine } = await import('../../engines/index.js');
-      const { TaskRunner } = await import('../../core/runner.js');
+      const { resolveEngine } = await import("../../engines/index.js");
+      const { TaskRunner } = await import("../../core/runner.js");
       const engine = resolveEngine(session.engine);
       const runner = new TaskRunner(runManager, sessionManager, engine);
       await runner.processRun(runId);
-      const result = readFileSync(path.join(opts.runsDir, runId, 'result.json'), 'utf-8');
-      process.stdout.write(result + '\n');
+      const result = readFileSync(
+        path.join(opts.runsDir, runId, "result.json"),
+        "utf-8",
+      );
+      process.stdout.write(result + "\n");
     });
 }

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -1,16 +1,22 @@
-import { Command } from 'commander';
-import { RunManager } from '../../core/run-manager.js';
-import { SessionManager } from '../../core/session-manager.js';
-import path from 'node:path';
-import { isProcessAlive } from '../../utils/process.js';
-import { makeError } from '../../schemas/errors.js';
+import { Command } from "commander";
+import { RunManager } from "../../core/run-manager.js";
+import { SessionManager } from "../../core/session-manager.js";
+import path from "node:path";
+import { isProcessAlive } from "../../utils/process.js";
+import { makeError } from "../../schemas/errors.js";
 
 function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
   return new Promise((resolve) => {
     const start = Date.now();
     const check = () => {
-      if (!isProcessAlive(pid)) { resolve(true); return; }
-      if (Date.now() - start > timeoutMs) { resolve(false); return; }
+      if (!isProcessAlive(pid)) {
+        resolve(true);
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        resolve(false);
+        return;
+      }
       setTimeout(check, 200);
     };
     check();
@@ -18,29 +24,55 @@ function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
 }
 
 export function stopCommand(): Command {
-  return new Command('stop')
-    .description('Stop a running task')
-    .argument('<run_id>', 'Run ID to stop')
-    .option('--runs-dir <path>', 'Runs directory', path.join(process.cwd(), '.runs'))
-    .option('--force-timeout <ms>', 'Time to wait for graceful exit before SIGKILL', '5000')
+  return new Command("stop")
+    .description("Stop a running task")
+    .argument("<run_id>", "Run ID to stop")
+    .option(
+      "--runs-dir <path>",
+      "Runs directory",
+      path.join(process.cwd(), ".runs"),
+    )
+    .option(
+      "--force-timeout <ms>",
+      "Time to wait for graceful exit before SIGKILL",
+      "5000",
+    )
     .action(async (runId, opts) => {
       const runManager = new RunManager(opts.runsDir);
       const sessionManager = new SessionManager(runManager);
       const session = await runManager.getStatus(runId);
 
-      if (session.state !== 'running') {
-        process.stderr.write(`Run ${runId} is not running (state: ${session.state})\n`);
+      const forceTimeoutMs = parseInt(opts.forceTimeout, 10);
+      if (!Number.isInteger(forceTimeoutMs) || forceTimeoutMs <= 0) {
+        process.stderr.write(
+          `Error: --force-timeout must be a positive integer (got: ${opts.forceTimeout})\n`,
+        );
         process.exit(1);
       }
 
-      await sessionManager.transition(runId, 'stopping');
+      if (session.state !== "running") {
+        process.stderr.write(
+          `Run ${runId} is not running (state: ${session.state})\n`,
+        );
+        process.exit(1);
+      }
+
+      await sessionManager.transition(runId, "stopping");
 
       let stopped = true;
       if (session.pid) {
-        try { process.kill(session.pid, 'SIGTERM'); } catch { /* already dead */ }
-        const exited = await waitForExit(session.pid, parseInt(opts.forceTimeout));
+        try {
+          process.kill(session.pid, "SIGTERM");
+        } catch {
+          /* already dead */
+        }
+        const exited = await waitForExit(session.pid, forceTimeoutMs);
         if (!exited) {
-          try { process.kill(session.pid, 'SIGKILL'); } catch { /* already dead */ }
+          try {
+            process.kill(session.pid, "SIGKILL");
+          } catch {
+            /* already dead */
+          }
           await waitForExit(session.pid, 2000);
         }
         stopped = !isProcessAlive(session.pid);
@@ -48,18 +80,25 @@ export function stopCommand(): Command {
 
       // Force-stopped tasks are marked failed so consumers do not treat
       // unfinished work as successful completion.
-      await sessionManager.transition(runId, 'failed');
+      await sessionManager.transition(runId, "failed");
       await runManager.writeResult(runId, {
         run_id: runId,
-        status: 'failed',
-        summary: 'Task force-stopped by user',
+        status: "failed",
+        summary: "Task force-stopped by user",
         session_id: session.session_id ?? null,
         artifacts: [],
         duration_ms: 0,
         token_usage: null,
-        error: makeError('TASK_STOPPED', stopped ? undefined : 'Task stop requested but process did not exit cleanly'),
+        error: makeError(
+          "TASK_STOPPED",
+          stopped
+            ? undefined
+            : "Task stop requested but process did not exit cleanly",
+        ),
       });
 
-      process.stdout.write(JSON.stringify({ run_id: runId, status: 'stopped' }, null, 2) + '\n');
+      process.stdout.write(
+        JSON.stringify({ run_id: runId, status: "stopped" }, null, 2) + "\n",
+      );
     });
 }

--- a/src/cli/commands/submit.ts
+++ b/src/cli/commands/submit.ts
@@ -1,46 +1,80 @@
-import { Command } from 'commander';
-import { RunManager } from '../../core/run-manager.js';
-import path from 'node:path';
+import { Command } from "commander";
+import { RunManager } from "../../core/run-manager.js";
+import { validateRequest } from "../../schemas/request.js";
+import path from "node:path";
 
 export function submitCommand(): Command {
-  return new Command('submit')
-    .description('Submit a new coding task')
-    .requiredOption('--intent <type>', 'Task intent: coding, refactor, debug, ops')
-    .requiredOption('--workspace <path>', 'Workspace directory path')
-    .requiredOption('--message <text>', 'Task description / prompt')
-    .option('--engine <name>', 'Engine to use', 'claude-code')
-    .option('--model <name>', 'Model to use (engine-specific)')
-    .option('--wait', 'Block until task completes', false)
-    .option('--timeout <ms>', 'Timeout in milliseconds', '1800000')
-    .option('--runs-dir <path>', 'Runs directory', path.join(process.cwd(), '.runs'))
+  return new Command("submit")
+    .description("Submit a new coding task")
+    .requiredOption(
+      "--intent <type>",
+      "Task intent: coding, refactor, debug, ops",
+    )
+    .requiredOption("--workspace <path>", "Workspace directory path")
+    .requiredOption("--message <text>", "Task description / prompt")
+    .option("--engine <name>", "Engine to use", "claude-code")
+    .option("--model <name>", "Model to use (engine-specific)")
+    .option("--wait", "Block until task completes", false)
+    .option("--timeout <ms>", "Timeout in milliseconds", "1800000")
+    .option(
+      "--runs-dir <path>",
+      "Runs directory",
+      path.join(process.cwd(), ".runs"),
+    )
     .action(async (opts) => {
-      const runManager = new RunManager(opts.runsDir);
-      const runId = await runManager.createRun({
+      const timeoutMs = parseInt(opts.timeout, 10);
+      const requestInput = {
         task_id: `task-${Date.now()}`,
         intent: opts.intent,
         workspace_path: path.resolve(opts.workspace),
         message: opts.message,
         engine: opts.engine,
-        mode: 'new',
-        constraints: { timeout_ms: parseInt(opts.timeout), allow_network: true },
+        mode: "new",
+        constraints: { timeout_ms: timeoutMs, allow_network: true },
         ...(opts.model ? { model: opts.model } : {}),
-      });
+      };
+      const validation = validateRequest(requestInput);
+      if (!validation.success) {
+        const issues = validation.error.issues.map((i) => {
+          const field = i.path.join(".");
+          return `  ${field}: ${i.message}`;
+        });
+        process.stderr.write(
+          `Error: invalid submit arguments:\n${issues.join("\n")}\n`,
+        );
+        process.exit(1);
+      }
+      const runManager = new RunManager(opts.runsDir);
+      const runId = await runManager.createRun(validation.data);
 
       if (!opts.wait) {
-        process.stdout.write(JSON.stringify({ run_id: runId, status: 'created', created_at: new Date().toISOString() }, null, 2) + '\n');
+        process.stdout.write(
+          JSON.stringify(
+            {
+              run_id: runId,
+              status: "created",
+              created_at: new Date().toISOString(),
+            },
+            null,
+            2,
+          ) + "\n",
+        );
         return;
       }
 
       // --wait mode
-      const { SessionManager } = await import('../../core/session-manager.js');
-      const { resolveEngine } = await import('../../engines/index.js');
-      const { TaskRunner } = await import('../../core/runner.js');
+      const { SessionManager } = await import("../../core/session-manager.js");
+      const { resolveEngine } = await import("../../engines/index.js");
+      const { TaskRunner } = await import("../../core/runner.js");
       const sessionManager = new SessionManager(runManager);
       const engine = resolveEngine(opts.engine);
       const runner = new TaskRunner(runManager, sessionManager, engine);
       await runner.processRun(runId);
-      const { readFileSync } = await import('node:fs');
-      const result = readFileSync(path.join(opts.runsDir, runId, 'result.json'), 'utf-8');
-      process.stdout.write(result + '\n');
+      const { readFileSync } = await import("node:fs");
+      const result = readFileSync(
+        path.join(opts.runsDir, runId, "result.json"),
+        "utf-8",
+      );
+      process.stdout.write(result + "\n");
     });
 }

--- a/tests/cli/resume.adversarial.test.ts
+++ b/tests/cli/resume.adversarial.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Adversarial tests for the `codebridge resume` CLI command.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const CLI = "npx tsx src/cli/index.ts";
+const CWD = process.cwd();
+
+describe("codebridge resume – adversarial", () => {
+  let workspaceDir: string;
+  let runsDir: string;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "cb-resumeadv-ws-"));
+    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), "cb-resumeadv-runs-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(runsDir, { recursive: true, force: true });
+  });
+
+  function submitAndComplete(intent = "coding"): string {
+    const submitOut = execSync(
+      `${CLI} submit --intent ${intent} --workspace "${workspaceDir}" --message "Initial task" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+    const { run_id } = JSON.parse(submitOut.trim());
+    const runDir = path.join(runsDir, run_id);
+
+    // Simulate task processed: consume request, mark completed with a session_id
+    fs.renameSync(
+      path.join(runDir, "request.json"),
+      path.join(runDir, "request.processing.json"),
+    );
+    const session = JSON.parse(
+      fs.readFileSync(path.join(runDir, "session.json"), "utf-8"),
+    );
+    session.state = "completed";
+    session.session_id = "sess-adv-test-123";
+    fs.writeFileSync(
+      path.join(runDir, "session.json"),
+      JSON.stringify(session),
+    );
+    return run_id;
+  }
+
+  // -----------------------------------------------------------------------
+  // Missing required arguments
+  // -----------------------------------------------------------------------
+  it("exits non-zero when --message is missing", () => {
+    const run_id = submitAndComplete();
+    const result = spawnSync(
+      "npx",
+      ["tsx", "src/cli/index.ts", "resume", run_id, "--runs-dir", runsDir],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  it("exits non-zero when run_id argument is missing", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "resume",
+        "--message",
+        "follow up",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Non-existent run_id
+  // -----------------------------------------------------------------------
+  it("exits non-zero when run_id does not exist", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "resume",
+        "run-doesnotexist",
+        "--message",
+        "follow up",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Bug #2 (issue #25): intent must be preserved from original request
+  // -----------------------------------------------------------------------
+  it("resume preserves original intent from request.processing.json, not hardcoded 'coding'", () => {
+    // submitAndComplete uses intent='refactor'; resume must carry that through
+    const run_id = submitAndComplete("refactor");
+    const runDir = path.join(runsDir, run_id);
+
+    execSync(
+      `${CLI} resume ${run_id} --message "Follow up" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+
+    const newRequest = JSON.parse(
+      fs.readFileSync(path.join(runDir, "request.json"), "utf-8"),
+    );
+    // Fix: resume must read intent from request.processing.json, not hardcode 'coding'
+    expect(newRequest.intent).toBe("refactor");
+  });
+
+  // -----------------------------------------------------------------------
+  // Bug #3 (issue #25): missing request.processing.json must be a hard error
+  // -----------------------------------------------------------------------
+  it("exits non-zero when request.processing.json is missing instead of silently using cwd", () => {
+    const run_id = submitAndComplete();
+    const runDir = path.join(runsDir, run_id);
+
+    // Remove request.processing.json so the fallback would previously trigger
+    fs.rmSync(path.join(runDir, "request.processing.json"));
+
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "resume",
+        run_id,
+        "--message",
+        "Follow up",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    // Fix: must exit non-zero rather than silently using process.cwd()
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/request\.processing\.json/i);
+  });
+
+  // -----------------------------------------------------------------------
+  // Resume output structure
+  // -----------------------------------------------------------------------
+  it('resume outputs run_id, status="resume_queued", and session_id', () => {
+    const run_id = submitAndComplete();
+
+    const result = execSync(
+      `${CLI} resume ${run_id} --message "Follow up" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+    const output = JSON.parse(result.trim());
+    expect(output.run_id).toBe(run_id);
+    expect(output.status).toBe("resume_queued");
+    expect(output.session_id).toBe("sess-adv-test-123");
+  });
+
+  // -----------------------------------------------------------------------
+  // Resume a run with no session_id should throw
+  // -----------------------------------------------------------------------
+  it("exits non-zero when run has no session_id", () => {
+    const submitOut = execSync(
+      `${CLI} submit --intent coding --workspace "${workspaceDir}" --message "No session" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+    const { run_id } = JSON.parse(submitOut.trim());
+    const runDir = path.join(runsDir, run_id);
+
+    // Simulate completion but with null session_id
+    fs.renameSync(
+      path.join(runDir, "request.json"),
+      path.join(runDir, "request.processing.json"),
+    );
+    const session = JSON.parse(
+      fs.readFileSync(path.join(runDir, "session.json"), "utf-8"),
+    );
+    session.state = "completed";
+    session.session_id = null; // No session_id
+    fs.writeFileSync(
+      path.join(runDir, "session.json"),
+      JSON.stringify(session),
+    );
+
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "resume",
+        run_id,
+        "--message",
+        "Follow up",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/tests/cli/stop.adversarial.test.ts
+++ b/tests/cli/stop.adversarial.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Adversarial tests for the `codebridge stop` CLI command.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const CLI = "npx tsx src/cli/index.ts";
+const CWD = process.cwd();
+
+describe("codebridge stop – adversarial", () => {
+  let runsDir: string;
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), "cb-stopadv-runs-"));
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "cb-stopadv-ws-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(runsDir, { recursive: true, force: true });
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // Missing run_id argument
+  // -----------------------------------------------------------------------
+  it("exits non-zero when run_id argument is missing", () => {
+    const result = spawnSync(
+      "npx",
+      ["tsx", "src/cli/index.ts", "stop", "--runs-dir", runsDir],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Non-existent run_id
+  // -----------------------------------------------------------------------
+  it("exits non-zero when run_id does not exist", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "stop",
+        "run-doesnotexist",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Stopping a run that is not running (already completed)
+  // -----------------------------------------------------------------------
+  it("exits non-zero when trying to stop an already-completed run", async () => {
+    const { RunManager } = await import("../../src/core/run-manager.js");
+    const { SessionManager } =
+      await import("../../src/core/session-manager.js");
+    const runManager = new RunManager(runsDir);
+    const sessionManager = new SessionManager(runManager);
+    const runId = await runManager.createRun({
+      task_id: "task-stop-adv",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Already done",
+      engine: "claude-code",
+      mode: "new",
+    });
+
+    // Transition to completed
+    await sessionManager.transition(runId, "running");
+    await sessionManager.transition(runId, "completed");
+
+    const result = spawnSync(
+      "npx",
+      ["tsx", "src/cli/index.ts", "stop", runId, "--runs-dir", runsDir],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    // stop.ts checks state !== 'running' and exits with code 1
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("not running");
+  });
+
+  // -----------------------------------------------------------------------
+  // Stopping a created (not yet started) run
+  // -----------------------------------------------------------------------
+  it("exits non-zero when trying to stop a created (not yet running) run", async () => {
+    const { RunManager } = await import("../../src/core/run-manager.js");
+    const runManager = new RunManager(runsDir);
+    const runId = await runManager.createRun({
+      task_id: "task-stop-adv-created",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Not started",
+      engine: "claude-code",
+      mode: "new",
+    });
+
+    const result = spawnSync(
+      "npx",
+      ["tsx", "src/cli/index.ts", "stop", runId, "--runs-dir", runsDir],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("not running");
+  });
+
+  // -----------------------------------------------------------------------
+  // Bug #4 (issue #25): --force-timeout with invalid (non-numeric) value
+  // -----------------------------------------------------------------------
+  it("exits non-zero when --force-timeout is non-numeric (NaN)", async () => {
+    // parseInt('abc') = NaN — if unvalidated, waitForExit's timeout check
+    // (`Date.now() - start > NaN`) always evaluates false, causing an infinite loop.
+    // Fix: validate --force-timeout is a positive integer before proceeding.
+    const { RunManager } = await import("../../src/core/run-manager.js");
+    const { SessionManager } =
+      await import("../../src/core/session-manager.js");
+    const runManager = new RunManager(runsDir);
+    const sessionManager = new SessionManager(runManager);
+    const runId = await runManager.createRun({
+      task_id: "task-stop-nan-timeout",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "NaN timeout test",
+      engine: "claude-code",
+      mode: "new",
+    });
+    await sessionManager.transition(runId, "running");
+
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "stop",
+        runId,
+        "--runs-dir",
+        runsDir,
+        "--force-timeout",
+        "abc",
+      ],
+      { encoding: "utf-8", cwd: CWD, timeout: 10000 },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/force-timeout/i);
+  });
+
+  it("exits non-zero when --force-timeout is zero", async () => {
+    const { RunManager } = await import("../../src/core/run-manager.js");
+    const { SessionManager } =
+      await import("../../src/core/session-manager.js");
+    const runManager = new RunManager(runsDir);
+    const sessionManager = new SessionManager(runManager);
+    const runId = await runManager.createRun({
+      task_id: "task-stop-zero-timeout",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Zero timeout test",
+      engine: "claude-code",
+      mode: "new",
+    });
+    await sessionManager.transition(runId, "running");
+
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "stop",
+        runId,
+        "--runs-dir",
+        runsDir,
+        "--force-timeout",
+        "0",
+      ],
+      { encoding: "utf-8", cwd: CWD, timeout: 10000 },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/force-timeout/i);
+  });
+});

--- a/tests/cli/submit.adversarial.test.ts
+++ b/tests/cli/submit.adversarial.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Adversarial tests for the `codebridge submit` CLI command.
+ *
+ * Probes argument validation, edge-case flag combinations, and
+ * path handling that the existing tests do not cover.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const CLI = "npx tsx src/cli/index.ts";
+const CWD = process.cwd();
+
+describe("codebridge submit – adversarial", () => {
+  let workspaceDir: string;
+  let runsDir: string;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "cb-adv-ws-"));
+    runsDir = fs.mkdtempSync(path.join(os.tmpdir(), "cb-adv-runs-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(runsDir, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // Missing required arguments
+  // -----------------------------------------------------------------------
+  it("exits non-zero when --intent is missing", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--workspace",
+        workspaceDir,
+        "--message",
+        "Do something",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  it("exits non-zero when --workspace is missing", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "coding",
+        "--message",
+        "Do something",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  it("exits non-zero when --message is missing", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "coding",
+        "--workspace",
+        workspaceDir,
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // --timeout with invalid values (Bug #1 — issue #25)
+  // -----------------------------------------------------------------------
+  it("exits non-zero when --timeout is 0 (non-positive)", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "coding",
+        "--workspace",
+        workspaceDir,
+        "--message",
+        "Test",
+        "--timeout",
+        "0",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/timeout/i);
+  });
+
+  it("exits non-zero when --timeout is negative", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "coding",
+        "--workspace",
+        workspaceDir,
+        "--message",
+        "Test",
+        "--timeout",
+        "-1",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/timeout/i);
+  });
+
+  it("exits non-zero when --timeout is non-numeric (NaN)", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "coding",
+        "--workspace",
+        workspaceDir,
+        "--message",
+        "Test",
+        "--timeout",
+        "abc",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/timeout/i);
+  });
+
+  // -----------------------------------------------------------------------
+  // --intent with invalid value (Bug #1 — issue #25)
+  // -----------------------------------------------------------------------
+  it("exits non-zero when --intent is an invalid value", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "hacking",
+        "--workspace",
+        workspaceDir,
+        "--message",
+        "Test",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/intent/i);
+  });
+
+  // -----------------------------------------------------------------------
+  // --engine with invalid value (Bug #1 — issue #25)
+  // -----------------------------------------------------------------------
+  it("exits non-zero when --engine is an unknown engine name", () => {
+    const result = spawnSync(
+      "npx",
+      [
+        "tsx",
+        "src/cli/index.ts",
+        "submit",
+        "--intent",
+        "coding",
+        "--workspace",
+        workspaceDir,
+        "--message",
+        "Test",
+        "--engine",
+        "gpt-4o",
+        "--runs-dir",
+        runsDir,
+      ],
+      { encoding: "utf-8", cwd: CWD },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/engine/i);
+  });
+
+  // -----------------------------------------------------------------------
+  // Workspace path handling
+  // -----------------------------------------------------------------------
+  it("resolves relative workspace path to absolute before writing request.json", () => {
+    // The CLI calls path.resolve(opts.workspace). Since we pass workspaceDir as an
+    // absolute path, verify the stored path is absolute. (Running with cwd=workspaceDir
+    // would fail because tsx cannot find src/cli/index.ts there, so we use CWD and
+    // pass the absolute path directly to confirm the path is preserved as absolute.)
+    const result = execSync(
+      `${CLI} submit --intent coding --workspace "${workspaceDir}" --message "Test" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+    const { run_id } = JSON.parse(result.trim());
+    const requestPath = path.join(runsDir, run_id, "request.json");
+    const request = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
+    expect(path.isAbsolute(request.workspace_path)).toBe(true);
+    expect(request.workspace_path).toBe(workspaceDir);
+  });
+
+  it("creates run directory and request.json with correct structure", () => {
+    const result = execSync(
+      `${CLI} submit --intent refactor --workspace "${workspaceDir}" --message "Refactor auth" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+    const { run_id } = JSON.parse(result.trim());
+    const requestPath = path.join(runsDir, run_id, "request.json");
+    expect(fs.existsSync(requestPath)).toBe(true);
+    const request = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
+    expect(request.intent).toBe("refactor");
+    expect(request.message).toBe("Refactor auth");
+    expect(request.mode).toBe("new");
+    expect(request.engine).toBe("claude-code"); // default
+  });
+
+  it('output JSON contains run_id with "run-" prefix and status "created"', () => {
+    const result = execSync(
+      `${CLI} submit --intent debug --workspace "${workspaceDir}" --message "Debug crash" --runs-dir "${runsDir}"`,
+      { encoding: "utf-8", cwd: CWD },
+    );
+    const output = JSON.parse(result.trim());
+    expect(output.run_id).toMatch(/^run-/);
+    expect(output.status).toBe("created");
+    expect(output.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO date
+  });
+
+  // -----------------------------------------------------------------------
+  // Workspace path with spaces and special chars
+  // -----------------------------------------------------------------------
+  it("handles workspace path with spaces correctly", () => {
+    const spacedDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "cb dir with spaces-"),
+    );
+    try {
+      const result = execSync(
+        `${CLI} submit --intent coding --workspace "${spacedDir}" --message "Test spaces" --runs-dir "${runsDir}"`,
+        { encoding: "utf-8", cwd: CWD },
+      );
+      const { run_id } = JSON.parse(result.trim());
+      const requestPath = path.join(runsDir, run_id, "request.json");
+      const request = JSON.parse(fs.readFileSync(requestPath, "utf-8"));
+      expect(request.workspace_path).toBe(spacedDir);
+    } finally {
+      fs.rmSync(spacedDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug 1 (submit):** Call `validateRequest()` (Zod schema) before `createRun()` so `--timeout abc/0/-1`, `--intent hacking`, and `--engine gpt-4o` all exit non-zero with a clear message instead of writing corrupt `request.json` to disk.
- **Bug 2 (resume):** Read `intent` from `request.processing.json` instead of hardcoding `'coding'`, preserving the original task intent across follow-up turns.
- **Bug 3 (resume):** Error out when `request.processing.json` is missing instead of silently falling back to `process.cwd()` as the workspace (which would resume against the wrong directory with no recovery path).
- **Bug 4 (stop):** Parse and validate `--force-timeout` before use; `parseInt('abc') = NaN` causes `Date.now() - start > NaN` to always evaluate `false`, making `waitForExit` spin forever if the subprocess does not self-exit.

## Test plan

- [ ] `npm test` — all 233 tests pass (zero regressions)
- [ ] `npx tsc --noEmit` — TypeScript compiles clean
- [ ] New adversarial test files cover each bug with red→green cycle:
  - `tests/cli/submit.adversarial.test.ts` — timeout (NaN/0/negative), invalid intent, invalid engine
  - `tests/cli/resume.adversarial.test.ts` — intent preservation, missing processing file error
  - `tests/cli/stop.adversarial.test.ts` — NaN force-timeout, zero force-timeout

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)