### PR TITLE
fix: ENGINE_TIMEOUT zero observability (#37)

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1,16 +1,30 @@
-import type { TaskRequest } from '../schemas/request.js';
+import type { TaskRequest } from "../schemas/request.js";
 
 export interface EngineResponse {
   output: string;
+  stderr?: string;
   pid: number;
   exitCode: number | null;
   sessionId: string | null;
-  error?: { code: string; message: string; retryable: boolean };
-  tokenUsage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | null;
+  error?: {
+    code: string;
+    message: string;
+    retryable: boolean;
+    detail?: string;
+  };
+  tokenUsage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  } | null;
 }
 
 export interface Engine {
   start(task: TaskRequest): Promise<EngineResponse>;
-  send(sessionId: string, message: string, opts?: { timeoutMs?: number; cwd?: string }): Promise<EngineResponse>;
+  send(
+    sessionId: string,
+    message: string,
+    opts?: { timeoutMs?: number; cwd?: string },
+  ): Promise<EngineResponse>;
   stop(pid: number): Promise<void>;
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -174,7 +174,9 @@ export class TaskRunner {
       const SUMMARY_LIMIT = 4000;
       const output = engineResponse.output;
       const summaryTruncated = output.length > SUMMARY_LIMIT;
-      const summary = summaryTruncated ? output.slice(0, SUMMARY_LIMIT) : output;
+      const summary = summaryTruncated
+        ? output.slice(0, SUMMARY_LIMIT)
+        : output;
 
       try {
         this.runManager.writeOutputFile(runId, output);
@@ -224,9 +226,15 @@ export class TaskRunner {
   private async fail(
     runId: string,
     startTime: number,
-    error: { code: string; message: string; retryable: boolean },
+    error: {
+      code: string;
+      message: string;
+      retryable: boolean;
+      detail?: string;
+    },
     engineResponse?: {
       output?: string;
+      stderr?: string;
       sessionId?: string | null;
       tokenUsage?: unknown;
     },
@@ -243,18 +251,35 @@ export class TaskRunner {
       /* best effort */
     }
 
+    // Write partial output.txt if the engine produced any output (best-effort)
+    let outputPath: string | null = null;
+    if (engineResponse?.output) {
+      try {
+        this.runManager.writeOutputFile(runId, engineResponse.output);
+        outputPath = path.join(this.runManager.getRunDir(runId), "output.txt");
+      } catch {
+        /* best effort — don't let output write failure block result.json */
+      }
+    }
+
+    // Merge stderr tail into error.detail for diagnostic context
+    const stderrTail = engineResponse?.stderr?.slice(-2000);
+    const mergedError = stderrTail
+      ? { ...error, detail: error.detail || stderrTail }
+      : error;
+
     await this.runManager.writeResult(runId, {
       run_id: runId,
       status: "failed",
       summary: error.message,
       summary_truncated: false,
-      output_path: null,
+      output_path: outputPath,
       session_id: engineResponse?.sessionId ?? null,
       artifacts: [],
       duration_ms: Date.now() - startTime,
       token_usage: null,
       files_changed: null,
-      error,
+      error: mergedError,
     });
   }
 }

--- a/src/engines/base-engine.ts
+++ b/src/engines/base-engine.ts
@@ -1,42 +1,78 @@
-import { spawn } from 'node:child_process';
-import path from 'node:path';
-import type { EngineResponse } from '../core/engine.js';
-import { makeError } from '../schemas/errors.js';
+import { spawn } from "node:child_process";
+import path from "node:path";
+import type { EngineResponse } from "../core/engine.js";
+import { makeError } from "../schemas/errors.js";
 
 export abstract class BaseEngine {
   static readonly MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 
-  protected exec(command: string, args: string[], timeoutMs: number, cwd?: string): Promise<EngineResponse> {
+  protected exec(
+    command: string,
+    args: string[],
+    timeoutMs: number,
+    cwd?: string,
+  ): Promise<EngineResponse> {
     return new Promise((resolve) => {
-      const extraBins = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin'];
+      const extraBins = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"];
       const home = process.env.HOME;
       if (home) {
-        extraBins.push(path.join(home, '.local', 'bin'));
-        extraBins.push(path.join(home, '.npm-global', 'bin'));
+        extraBins.push(path.join(home, ".local", "bin"));
+        extraBins.push(path.join(home, ".npm-global", "bin"));
       }
-      const mergedPath = [...new Set([...(process.env.PATH ?? '').split(':').filter(Boolean), ...extraBins])].join(':');
+      const mergedPath = [
+        ...new Set([
+          ...(process.env.PATH ?? "").split(":").filter(Boolean),
+          ...extraBins,
+        ]),
+      ].join(":");
 
       const child = spawn(command, args, {
         cwd: cwd || process.cwd(),
         env: { ...process.env, PATH: mergedPath },
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       });
 
-      let stdout = '';
-      let stderr = '';
+      let stdout = "";
+      let stderr = "";
       let timedOut = false;
       let outputOverflow = false;
       let totalBytes = 0;
       let killScheduled = false;
 
+      const killProcessGroup = (signal: NodeJS.Signals) => {
+        const pid = child.pid;
+        if (!pid) {
+          // pid is undefined (spawn failed) or 0 — fall back to direct kill
+          // process.kill(-0, signal) would kill the daemon's own process group
+          try {
+            child.kill(signal);
+          } catch {
+            /* already dead */
+          }
+          return;
+        }
+        try {
+          // Kill the entire process group (negative PID)
+          process.kill(-pid, signal);
+        } catch {
+          // Fallback to direct child kill if process group kill fails
+          try {
+            child.kill(signal);
+          } catch {
+            /* already dead */
+          }
+        }
+      };
+
       const escalateKill = () => {
         if (killScheduled) return;
         killScheduled = true;
-        child.kill('SIGTERM');
-        setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, 3000);
+        killProcessGroup("SIGTERM");
+        setTimeout(() => killProcessGroup("SIGKILL"), 3000);
       };
 
-      const captureChunk = (chunk: Buffer, target: 'stdout' | 'stderr') => {
+      const captureChunk = (chunk: Buffer, target: "stdout" | "stderr") => {
         if (outputOverflow) return;
         const incomingBytes = chunk.byteLength;
         const remaining = BaseEngine.MAX_OUTPUT_BYTES - totalBytes;
@@ -44,7 +80,7 @@ export abstract class BaseEngine {
         if (incomingBytes > remaining) {
           if (remaining > 0) {
             const partial = chunk.subarray(0, remaining).toString();
-            if (target === 'stdout') stdout += partial;
+            if (target === "stdout") stdout += partial;
             else stderr += partial;
             totalBytes += remaining;
           }
@@ -54,7 +90,7 @@ export abstract class BaseEngine {
         }
 
         const incoming = chunk.toString();
-        if (target === 'stdout') stdout += incoming;
+        if (target === "stdout") stdout += incoming;
         else stderr += incoming;
         totalBytes += incomingBytes;
       };
@@ -64,42 +100,93 @@ export abstract class BaseEngine {
         escalateKill();
       }, timeoutMs);
 
-      child.stdout?.on('data', (chunk: Buffer) => captureChunk(chunk, 'stdout'));
-      child.stderr?.on('data', (chunk: Buffer) => captureChunk(chunk, 'stderr'));
+      child.stdout?.on("data", (chunk: Buffer) =>
+        captureChunk(chunk, "stdout"),
+      );
+      child.stderr?.on("data", (chunk: Buffer) =>
+        captureChunk(chunk, "stderr"),
+      );
 
-      child.on('close', (code) => {
+      child.on("close", (code) => {
         clearTimeout(timer);
         if (timedOut) {
-          resolve({ output: stdout, pid: child.pid ?? 0, exitCode: code, sessionId: null, error: makeError('ENGINE_TIMEOUT', `Process killed after ${timeoutMs}ms`) });
+          resolve({
+            output: stdout,
+            stderr,
+            pid: child.pid ?? 0,
+            exitCode: code,
+            sessionId: null,
+            error: makeError(
+              "ENGINE_TIMEOUT",
+              `Process killed after ${timeoutMs}ms`,
+              stderr.slice(-2000) || undefined,
+            ),
+          });
           return;
         }
         if (outputOverflow) {
           resolve({
             output: stdout,
+            stderr,
             pid: child.pid ?? 0,
             exitCode: code,
             sessionId: null,
-            error: makeError('ENGINE_CRASH', `Engine output exceeded ${BaseEngine.MAX_OUTPUT_BYTES} bytes`),
+            error: makeError(
+              "ENGINE_CRASH",
+              `Engine output exceeded ${BaseEngine.MAX_OUTPUT_BYTES} bytes`,
+            ),
           });
           return;
         }
         if (code !== 0) {
-          resolve({ output: stdout, pid: child.pid ?? 0, exitCode: code, sessionId: null, error: makeError('ENGINE_CRASH', stderr || `Process exited with code ${code}`) });
+          resolve({
+            output: stdout,
+            stderr,
+            pid: child.pid ?? 0,
+            exitCode: code,
+            sessionId: null,
+            error: makeError(
+              "ENGINE_CRASH",
+              stderr || `Process exited with code ${code}`,
+            ),
+          });
           return;
         }
         try {
-          resolve(this.parseOutput(stdout, stderr, child.pid ?? 0));
+          const parsed = this.parseOutput(stdout, stderr, child.pid ?? 0);
+          resolve({ ...parsed, stderr });
         } catch (err) {
-          resolve({ output: stdout, pid: child.pid ?? 0, exitCode: code, sessionId: null, error: makeError('ENGINE_CRASH', `Output parse error: ${(err as Error).message}`) });
+          resolve({
+            output: stdout,
+            stderr,
+            pid: child.pid ?? 0,
+            exitCode: code,
+            sessionId: null,
+            error: makeError(
+              "ENGINE_CRASH",
+              `Output parse error: ${(err as Error).message}`,
+            ),
+          });
         }
       });
 
-      child.on('error', (err) => {
+      child.on("error", (err) => {
         clearTimeout(timer);
-        resolve({ output: '', pid: child.pid ?? 0, exitCode: null, sessionId: null, error: makeError('ENGINE_CRASH', err.message) });
+        resolve({
+          output: "",
+          stderr,
+          pid: child.pid ?? 0,
+          exitCode: null,
+          sessionId: null,
+          error: makeError("ENGINE_CRASH", err.message),
+        });
       });
     });
   }
 
-  protected abstract parseOutput(stdout: string, stderr: string, pid: number): EngineResponse;
+  protected abstract parseOutput(
+    stdout: string,
+    stderr: string,
+    pid: number,
+  ): EngineResponse;
 }

--- a/src/schemas/errors.ts
+++ b/src/schemas/errors.ts
@@ -53,12 +53,13 @@ export const ERROR_CODES = {
 
 export type ErrorCode = keyof typeof ERROR_CODES;
 
-export function makeError(code: ErrorCode, detail?: string) {
+export function makeError(code: ErrorCode, message?: string, detail?: string) {
   const info = ERROR_CODES[code];
   return {
     code,
-    message: detail || info.message,
+    message: message || info.message,
     retryable: info.retryable,
     suggestion: info.suggestion,
+    ...(detail ? { detail } : {}),
   };
 }

--- a/src/schemas/result.ts
+++ b/src/schemas/result.ts
@@ -6,6 +6,7 @@ const ErrorSchema = z.object({
   message: z.string(),
   retryable: z.boolean(),
   suggestion: z.string().optional(),
+  detail: z.string().optional(),
 });
 
 const TokenUsageSchema = z

--- a/tests/core/runner.test.ts
+++ b/tests/core/runner.test.ts
@@ -481,6 +481,109 @@ describe("TaskRunner", () => {
     expect(fs.existsSync(outputPath)).toBe(false);
   });
 
+  it("writes output.txt on failure when engine has partial output", async () => {
+    // Engine that produces output but exits non-zero
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo 'partial work done'; exit 1"],
+    });
+    const runner = new TaskRunner(runManager, sessionManager, engine);
+    const runId = await runManager.createRun({
+      task_id: "task-partial-out",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Partial output on failure",
+      engine: "claude-code",
+      mode: "new",
+    });
+
+    await runner.processRun(runId);
+
+    const resultPath = path.join(runsDir, runId, "result.json");
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(result.status).toBe("failed");
+    // output.txt should exist because engine produced non-empty output
+    const outputPath = path.join(runsDir, runId, "output.txt");
+    expect(fs.existsSync(outputPath)).toBe(true);
+    expect(fs.readFileSync(outputPath, "utf-8")).toContain("partial work done");
+    expect(path.isAbsolute(result.output_path)).toBe(true);
+  });
+
+  it("does NOT write output.txt when engine output is empty on failure", async () => {
+    const engine = new ClaudeCodeEngine({ command: "false" });
+    const runner = new TaskRunner(runManager, sessionManager, engine);
+    const runId = await runManager.createRun({
+      task_id: "task-empty-fail",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Empty output failure",
+      engine: "claude-code",
+      mode: "new",
+    });
+
+    await runner.processRun(runId);
+
+    const resultPath = path.join(runsDir, runId, "result.json");
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(result.status).toBe("failed");
+    expect(result.output_path).toBeNull();
+    const outputPath = path.join(runsDir, runId, "output.txt");
+    expect(fs.existsSync(outputPath)).toBe(false);
+  });
+
+  it("result.json includes stderr in error.detail on failure", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo 'connection refused' >&2; exit 1"],
+    });
+    const runner = new TaskRunner(runManager, sessionManager, engine);
+    const runId = await runManager.createRun({
+      task_id: "task-stderr-detail",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Stderr in detail",
+      engine: "claude-code",
+      mode: "new",
+    });
+
+    await runner.processRun(runId);
+
+    const resultPath = path.join(runsDir, runId, "result.json");
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(result.status).toBe("failed");
+    expect(result.error.detail).toContain("connection refused");
+  });
+
+  it("writes output.txt on ENGINE_TIMEOUT with partial stdout", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo 'pre-timeout output'; exec sleep 30"],
+    });
+    const runner = new TaskRunner(runManager, sessionManager, engine);
+    const runId = await runManager.createRun({
+      task_id: "task-timeout-out",
+      intent: "coding",
+      workspace_path: workspaceDir,
+      message: "Timeout with output",
+      engine: "claude-code",
+      mode: "new",
+      constraints: { timeout_ms: 500, allow_network: true },
+    });
+
+    await runner.processRun(runId);
+
+    const resultPath = path.join(runsDir, runId, "result.json");
+    const result = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+    expect(result.status).toBe("failed");
+    expect(result.error.code).toBe("ENGINE_TIMEOUT");
+    const outputPath = path.join(runsDir, runId, "output.txt");
+    expect(fs.existsSync(outputPath)).toBe(true);
+    expect(fs.readFileSync(outputPath, "utf-8")).toContain(
+      "pre-timeout output",
+    );
+    expect(path.isAbsolute(result.output_path)).toBe(true);
+  }, 15000);
+
   it("still writes result.json when writeOutputFile throws", async () => {
     const engine = new ClaudeCodeEngine({
       command: "echo",

--- a/tests/engines/base-engine-stderr.test.ts
+++ b/tests/engines/base-engine-stderr.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for stderr capture in BaseEngine.exec()
+ *
+ * Phase 1: stderr field on EngineResponse
+ * Phase 3: stderr surfaced in error.detail
+ * Phase 4: process group kill (detached: true)
+ */
+import { describe, it, expect } from "vitest";
+import { ClaudeCodeEngine } from "../../src/engines/claude-code.js";
+import type { TaskRequest } from "../../src/schemas/request.js";
+
+const makeRequest = (overrides?: Partial<TaskRequest>): TaskRequest => ({
+  task_id: "t1",
+  intent: "coding",
+  workspace_path: "/tmp",
+  message: "test",
+  engine: "claude-code",
+  mode: "new",
+  session_id: null,
+  constraints: { timeout_ms: 30000, allow_network: true },
+  ...overrides,
+});
+
+describe("BaseEngine — stderr capture", () => {
+  // Phase 1: stderr field present on all exit paths
+
+  it("includes stderr on success (exit 0)", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo ok; echo err-msg >&2"],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.stderr).toBe("err-msg\n");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("includes stderr on ENGINE_TIMEOUT", { timeout: 15000 }, async () => {
+    // Use exec to replace bash with sleep so SIGTERM kills the process directly
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo timeout-stderr >&2; exec sleep 30"],
+    });
+    const result = await engine.start(
+      makeRequest({ constraints: { timeout_ms: 500, allow_network: true } }),
+    );
+    expect(result.error?.code).toBe("ENGINE_TIMEOUT");
+    expect(result.stderr).toContain("timeout-stderr");
+  });
+
+  it("includes stderr on ENGINE_CRASH (exit 1)", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo crash-stderr >&2; exit 1"],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.error?.code).toBe("ENGINE_CRASH");
+    expect(result.stderr).toContain("crash-stderr");
+  });
+
+  it("includes stderr on output overflow", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: [
+        "-c",
+        "echo overflow-stderr >&2; dd if=/dev/zero bs=1048576 count=11 2>/dev/null",
+      ],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.error?.code).toBe("ENGINE_CRASH");
+    expect(result.stderr).toContain("overflow-stderr");
+  });
+
+  // Phase 3: stderr surfaced in error.detail
+
+  it(
+    "timeout error includes stderr in detail",
+    { timeout: 15000 },
+    async () => {
+      const engine = new ClaudeCodeEngine({
+        command: "bash",
+        defaultArgs: [
+          "-c",
+          "echo 'auth-failure: token expired' >&2; exec sleep 30",
+        ],
+      });
+      const result = await engine.start(
+        makeRequest({ constraints: { timeout_ms: 500, allow_network: true } }),
+      );
+      expect(result.error?.code).toBe("ENGINE_TIMEOUT");
+      expect(result.error?.detail).toContain("auth-failure: token expired");
+    },
+  );
+
+  it("stderr is empty string on spawn error (ENOENT)", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "/nonexistent-binary-xyz-12345",
+      defaultArgs: [],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.error?.code).toBe("ENGINE_CRASH");
+    expect(result.stderr).toBe("");
+    expect(result.error?.detail).toBeUndefined();
+  });
+
+  it("includes stderr on output parse error (exit 0, non-JSON)", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "echo parse-err-stderr >&2; echo 'not-json'"],
+    });
+    const result = await engine.start(makeRequest());
+    // ClaudeCodeEngine.parseOutput doesn't throw on non-JSON — it falls back to raw stdout.
+    // But the stderr should still be captured regardless of exit path.
+    expect(result.stderr).toContain("parse-err-stderr");
+  });
+
+  it("stderr is empty string when no stderr", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "echo",
+      defaultArgs: ["no-stderr-here"],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.stderr).toBe("");
+  });
+
+  // Phase 4: process group kill (detached: true)
+
+  it("kills child process tree on timeout", { timeout: 15000 }, async () => {
+    // Spawn a bash that starts a grandchild (sleep), write grandchild PID to stderr
+    // After timeout, both should be dead
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: ["-c", "sleep 60 & echo GRANDCHILD_PID=$! >&2; wait"],
+    });
+    const result = await engine.start(
+      makeRequest({ constraints: { timeout_ms: 500, allow_network: true } }),
+    );
+    expect(result.error?.code).toBe("ENGINE_TIMEOUT");
+
+    // Extract grandchild PID from stderr
+    const match = result.stderr?.match(/GRANDCHILD_PID=(\d+)/);
+    expect(match).not.toBeNull();
+    const grandchildPid = Number(match![1]);
+
+    // Give OS a moment to reap
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Grandchild should be dead
+    let alive = false;
+    try {
+      process.kill(grandchildPid, 0); // signal 0 = probe
+      alive = true;
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+
+  it("kills child process tree on overflow", { timeout: 15000 }, async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "bash",
+      defaultArgs: [
+        "-c",
+        "sleep 60 & echo GRANDCHILD_PID=$! >&2; dd if=/dev/zero bs=1048576 count=11 2>/dev/null; wait",
+      ],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.error?.code).toBe("ENGINE_CRASH");
+
+    const match = result.stderr?.match(/GRANDCHILD_PID=(\d+)/);
+    expect(match).not.toBeNull();
+    const grandchildPid = Number(match![1]);
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    let alive = false;
+    try {
+      process.kill(grandchildPid, 0);
+      alive = true;
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+
+  it("normal exit works with detached:true (smoke test)", async () => {
+    const engine = new ClaudeCodeEngine({
+      command: "echo",
+      defaultArgs: ["detached-works"],
+    });
+    const result = await engine.start(makeRequest());
+    expect(result.error).toBeUndefined();
+    expect(result.output).toContain("detached-works");
+  });
+});

--- a/tests/schemas/errors.test.ts
+++ b/tests/schemas/errors.test.ts
@@ -67,4 +67,20 @@ describe("makeError", () => {
     const err = makeError("ENGINE_TIMEOUT", "Custom message");
     expect(err.message).toBe("Custom message");
   });
+
+  it("includes detail when 3rd arg provided", () => {
+    const err = makeError("ENGINE_TIMEOUT", "Timed out", "stderr context here");
+    expect(err.detail).toBe("stderr context here");
+    expect(err.message).toBe("Timed out");
+  });
+
+  it("omits detail when 3rd arg absent", () => {
+    const err = makeError("ENGINE_TIMEOUT");
+    expect("detail" in err).toBe(false);
+  });
+
+  it("omits detail when 3rd arg is empty string", () => {
+    const err = makeError("ENGINE_TIMEOUT", "Timed out", "");
+    expect("detail" in err).toBe(false);
+  });
 });

--- a/tests/schemas/result.test.ts
+++ b/tests/schemas/result.test.ts
@@ -320,4 +320,41 @@ describe("ResultSchema", () => {
     const result = validateResult(input);
     expect(result.success).toBe(true);
   });
+
+  it("accepts error with detail field", () => {
+    const input = {
+      ...validSuccess,
+      status: "failed",
+      error: {
+        code: "ENGINE_TIMEOUT",
+        message: "Timed out",
+        retryable: true,
+        detail: "connection refused to vertex-ai.googleapis.com",
+      },
+    };
+    const result = validateResult(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.error!.detail).toBe(
+        "connection refused to vertex-ai.googleapis.com",
+      );
+    }
+  });
+
+  it("accepts error without detail (backward compat)", () => {
+    const input = {
+      ...validSuccess,
+      status: "failed",
+      error: {
+        code: "ENGINE_TIMEOUT",
+        message: "Timed out",
+        retryable: true,
+      },
+    };
+    const result = validateResult(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.error!.detail).toBeUndefined();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #37 — all Vertex AI Gemini tasks via `codebridge submit --engine opencode` fail with `ENGINE_TIMEOUT` after 30 minutes with zero diagnostic information.

**Root cause**: `BaseEngine.exec()` captured stderr but discarded it on timeout. `TaskRunner.fail()` never wrote `output.txt` on failure. The error schema had no field for stderr context. Process kills didn't use process groups, so child processes survived.

**4-phase BDD fix:**

- **Phase 1**: Add `stderr` field to `EngineResponse` — populated in all 5 resolve paths (timeout, overflow, crash, success, spawn-error)
- **Phase 2**: Write `output.txt` on failure when engine has non-empty partial output — preserves pre-timeout work
- **Phase 3**: Add `detail` field to `ErrorSchema` — surfaces stderr tail (last 2000 chars) in `result.json` error so users see _why_ the timeout happened (auth failure, connection refused, etc.)
- **Phase 4**: Process group kill — `detached: true` + `process.kill(-pid, signal)` ensures child process trees are killed on timeout, preventing orphaned processes that accumulate over time

## Files changed

| File | Changes |
|------|---------|
| `src/core/engine.ts` | `stderr?: string` + `detail?: string` on error type |
| `src/engines/base-engine.ts` | stderr in responses, detail in makeError, process group kill |
| `src/core/runner.ts` | Write output.txt on failure, forward stderr as detail |
| `src/schemas/errors.ts` | `makeError(code, message?, detail?)` with conditional spread |
| `src/schemas/result.ts` | `detail: z.string().optional()` in ErrorSchema |
| `tests/engines/base-engine-stderr.test.ts` | **New** — 9 tests (stderr capture, detail, process group kill) |
| `tests/core/runner.test.ts` | 4 tests added (partial output, stderr detail) |
| `tests/schemas/errors.test.ts` | 2 tests added (detail param) |
| `tests/schemas/result.test.ts` | 2 tests added (detail field schema) |

## Test plan

- [x] 650 tests pass (`npm test`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] All 17 new tests written BDD-style (failing first, then green)
- [x] Existing adversarial test 13 (empty output → null output_path) still passes
- [x] `makeError` backward compat: existing `toEqual` assertions still green
- [ ] Manual smoke: script writing to stderr + timeout → verify `result.json` has `error.detail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)