### PR TITLE
fix: use opencode native -f flag for images

### DIFF
--- a/src/engines/opencode.ts
+++ b/src/engines/opencode.ts
@@ -59,7 +59,12 @@ export class OpenCodeEngine extends BaseEngine implements Engine {
     if (task.model) {
       args.push("-m", task.model);
     }
-    args.push(this.injectImagePaths(task.message, task.images));
+    if (task.images && task.images.length > 0) {
+      for (const img of task.images) {
+        args.push("-f", img);
+      }
+    }
+    args.push("--", task.message);
     return args;
   }
 


### PR DESCRIPTION
## Summary

- Replace `injectImagePaths` text injection with opencode's native `-f` flag for multimodal support
- Add `--` separator before the positional message argument to prevent opencode from misinterpreting the message as a file path
- Fixes test/source mismatch from PR #40 squash merge where the test expected `-f` flags but the source still used text injection

## Context

Local testing revealed that `injectImagePaths` only puts text paths in the message — the model sees `[Attached image: /path]` as text, not actual image data. Using opencode's native `-f` flag enables real multimodal support through the multimodal-looker agent delegation.

## Test plan

- [x] All 674 tests pass (including the `-f` flag assertions from PR #40)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)