### PR TITLE
ci: migrate Actions to self-hosted Mac runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS]
 
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4


### PR DESCRIPTION
## Summary

- Move GitHub Actions jobs off GitHub-hosted runners and onto Pawpaw's self-hosted Mac runner labels.
- Preserve existing self-hosted, HIL, stage, builder, and hardware-specific jobs.
- Keep build/test/release steps and trigger behavior unchanged.

## Architecture / Flow

```mermaid
flowchart LR
    Before["Before: GitHub-hosted runner"] --> Job["GitHub Actions job"]
    After["After: Pawpaw self-hosted Mac"] --> Job
    style After fill:#ff9,stroke:#333
```

## File Changes

```text
.github/workflows/ci.yml                         ██░░░░░░░░░░░░░░░░░░░░ 1+ 1-
.github/workflows/release-please.yml             ██░░░░░░░░░░░░░░░░░░░░ 1+ 1-
```

## Verification

```text
Ruby/Psych YAML parse: passed
Resolved runs-on scan: 0 GitHub-hosted selectors remaining
git diff --check: passed
Diff scope: workflow files only
actionlint: passed with 0 diagnostics
```

## Risks / Follow-ups

- CI execution is the authoritative check that the selected Mac runner has every required CLI, Docker service, and network dependency.
- Jobs originally authored for Ubuntu or Windows may contain platform assumptions that static YAML validation cannot exercise.
- This PR does not merge or alter the default branch directly.

---

Generated with an AI coding agent.
